### PR TITLE
Added Ordering and cats.kernel.Order instance

### DIFF
--- a/core/shared/src/main/scala/org/http4s/HttpVersion.scala
+++ b/core/shared/src/main/scala/org/http4s/HttpVersion.scala
@@ -22,6 +22,8 @@ import cats.kernel.BoundedEnumerable
 import cats.parse.{Parser => P}
 import cats.parse.Rfc5234.digit
 import org.http4s.util._
+import cats.kernel.Order
+
 
 /** An HTTP version, as seen on the start line of an HTTP request or response.
   *
@@ -101,4 +103,7 @@ object HttpVersion {
     override def minBound: HttpVersion = HttpVersion(0, 0)
     override def maxBound: HttpVersion = HttpVersion(9, 9)
   }
+
+  implicit val stdLibOrderingInstance: Ordering[HttpVersion] =
+    catsInstancesForHttp4sHttpVersion.toOrdering 
 }


### PR DESCRIPTION
Contributing to issue #5017

Changed file HttpVersion.scala
Added `Ordering` and `cats.kernel.Order` instance to `HttpVersion` class